### PR TITLE
Please for the love of god make these settings off by default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# v1.1.2
+- Make "show in practice mode/startpos mode/platformer mode" settings off by default.
+- Bump geode version
 # v1.1.1
 - Bump geode version
 # v1.1.0

--- a/mod.json
+++ b/mod.json
@@ -6,7 +6,7 @@
 		"android": "2.2074",
 		"ios": "2.2074"
 	},
-	"version": "v1.1.1",
+	"version": "v1.1.2",
 	"id": "firee.goldenbest",
 	"name": "Golden Best",
 	"developer": "Firee",


### PR DESCRIPTION
I am going slightly more insane every time I see someone that has their from-zero best show as golden in practice mode/startpos mode. Please change the default setting values. There is no reason anyone would actually want to see their from-zero best in practice mode. Please. For my sanity. 🙏